### PR TITLE
Properly ignore user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-Demo/FontAwesome-iOS Demo.xcodeproj/project.xcworkspace/xcuserdata/runemadsen.xcuserdatad/UserInterfaceState.xcuserstate
-Demo/FontAwesome-iOS Demo.xcodeproj/xcuserdata/runemadsen.xcuserdatad/xcdebugger/Breakpoints.xcbkptlist
-Demo/FontAwesome-iOS Demo.xcodeproj/xcuserdata/runemadsen.xcuserdatad/xcschemes/FontAwesome-iOS Demo.xcscheme
-Demo/FontAwesome-iOS Demo.xcodeproj/xcuserdata/runemadsen.xcuserdatad/xcschemes/xcschememanagement.plist
+xcuserdata
 .DS_Store


### PR DESCRIPTION
Stop tracking any xcuserdata directories (yours and anyone who clones this). If you include this project as a submodule, it will continually be in a "dirty" state, because xcode will write xcuserdata files. By adding this, it will be nicer to use your project as a submodule.
