### PR TITLE
Center align icons when rendering as UIImage's

### DIFF
--- a/UIImage+FontAwesome.m
+++ b/UIImage+FontAwesome.m
@@ -78,9 +78,12 @@ int fa_constraintLabelToSize(UILabel *label, CGSize size, int maxFontSize, int m
     }
     [iconColor setFill];
     
+    NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    style.alignment = NSTextAlignmentCenter;
     [textContent drawInRect:textRect withAttributes:@{NSFontAttributeName : font,
                                                       NSForegroundColorAttributeName : iconColor,
-                                                      NSBackgroundColorAttributeName : bgColor
+                                                      NSBackgroundColorAttributeName : bgColor,
+                                                      NSParagraphStyleAttributeName: style,
                                                       }];
 
     //Image returns
@@ -101,9 +104,12 @@ int fa_constraintLabelToSize(UILabel *label, CGSize size, int maxFontSize, int m
     //// Abstracted Attributes
     NSString* textContent = [NSString fontAwesomeIconStringForIconIdentifier:identifier];
     UIFont *font = [UIFont fontWithName:kFontAwesomeFamilyName size:fontSize];
+    NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    style.alignment = NSTextAlignmentCenter;
     NSDictionary *attributes = @{NSFontAttributeName : font,
                                  NSForegroundColorAttributeName : iconColor,
                                  NSBackgroundColorAttributeName : bgColor,
+                                 NSParagraphStyleAttributeName: style,
                                  };
     
     //// Content Edge Insets


### PR DESCRIPTION
This makes this:

![image](https://cloud.githubusercontent.com/assets/120155/9090354/0174b790-3b57-11e5-8241-ed56e12ca9fd.png)

become this:

![image](https://cloud.githubusercontent.com/assets/120155/9090340/ec041b12-3b56-11e5-89ac-9b824de8628f.png)
